### PR TITLE
CWA-2024-009: Mention wasmvm 1.5.7 and add wasmd 0.34.1

### DIFF
--- a/CWAs/CWA-2024-009.md
+++ b/CWAs/CWA-2024-009.md
@@ -6,7 +6,7 @@ Low (Marginal + Likely)[^1]
 
 **Affected versions:**
 
-- wasmd > 0.34.1, < 0.53.1
+- wasmd > 0.40.0, < 0.53.1
 - wasmd < 0.34.1
 
 **Patched versions:**

--- a/CWAs/CWA-2024-009.md
+++ b/CWAs/CWA-2024-009.md
@@ -28,7 +28,7 @@ These can then easily be thrown away and replaced with new instances in case of 
 The patch requires upgrading wasmvm to 1.5.7, 2.0.5 or 2.1.4 and then apply this diff for Cosmos SDK 0.50 chains:<br/>
 https://github.com/CosmWasm/wasmd/compare/80760aea336f0f1ad34756b0f03267d98cac6a04...v0.53.2
 or this diff for chains using an older Cosmos SDK:<br/>
-https://github.com/CosmWasm/wasmd/compare/bcf947dd265d385f5abfd5182468e5322699fcae...v0.34.1
+https://github.com/CosmWasm/wasmd/compare/96634f38903fa31e54f49a00018613cd9a29598e...v0.34.1
 
 ## Applying the patch
 

--- a/CWAs/CWA-2024-009.md
+++ b/CWAs/CWA-2024-009.md
@@ -51,8 +51,8 @@ If you are instead using wasmvm 2.1.2, then upgrading to 2.1.4 includes the cons
 
 ### DIY Patch
 
-If you are unable to upgrade to the latest version, you can backport the wasmd patch to your version. The patch is available at [Wasmd 0.53.2](https://github.com/CosmWasm/wasmd/compare/v0.53.0...v0.53.2) and the .
-However, if you are on an older version of wasmd, you will also be using a different version of wasmvm. We provide the required patches for wasmvm in versions 2.1.4, 2.0.5, 1.5.7.
+If you are unable to upgrade to the latest version, you can backport the wasmd patch to your version. The patch is available at [Wasmd 0.53.2](https://github.com/CosmWasm/wasmd/compare/v0.53.0...v0.53.2) and at [Wasmd 0.34.1](https://github.com/CosmWasm/wasmd/compare/v0.34.0...v0.34.1).
+However, if you are on a different version of wasmd, you will also be using a different version of wasmvm. We provide the required patches for wasmvm in versions 2.1.4, 2.0.5, 1.5.7.
 To upgrade using this method:
 
 1. Check the current wasmvm version: `go list -m github.com/CosmWasm/wasmvm` and upgrade

--- a/CWAs/CWA-2024-009.md
+++ b/CWAs/CWA-2024-009.md
@@ -6,11 +6,13 @@ Low (Marginal + Likely)[^1]
 
 **Affected versions:**
 
-- wasmd < 0.53.1
+- wasmd > 0.34.1, < 0.53.1
+- wasmd < 0.34.1
 
 **Patched versions:**
 
 - wasmd 0.53.2 (please note that wasmd 0.53.1 is broken and must not be used)
+- wasmd 0.34.1
 
 ## Description of the bug
 
@@ -23,8 +25,10 @@ These can then easily be thrown away and replaced with new instances in case of 
 
 ## Patch
 
-The patch requires upgrading wasmvm to 1.5.6, 2.0.5 or 2.1.4 and then apply this diff:<br/>
+The patch requires upgrading wasmvm to 1.5.7, 2.0.5 or 2.1.4 and then apply this diff for Cosmos SDK 0.50 chains:<br/>
 https://github.com/CosmWasm/wasmd/compare/80760aea336f0f1ad34756b0f03267d98cac6a04...v0.53.2
+or this diff for chains using an older Cosmos SDK:<br/>
+https://github.com/CosmWasm/wasmd/compare/bcf947dd265d385f5abfd5182468e5322699fcae...v0.34.1
 
 ## Applying the patch
 
@@ -47,19 +51,19 @@ If you are instead using wasmvm 2.1.2, then upgrading to 2.1.4 includes the cons
 
 ### DIY Patch
 
-If you are unable to upgrade to the latest version, you can backport the wasmd patch to your version. The patch is available at [Wasmd 0.53.2](https://github.com/CosmWasm/wasmd/compare/v0.53.0...v0.53.2).
-However, if you are on an older version of wasmd, you will also be using a different version of wasmvm. We provide the required patches for wasmvm in versions 2.1.4, 2.0.5, 1.5.6.
+If you are unable to upgrade to the latest version, you can backport the wasmd patch to your version. The patch is available at [Wasmd 0.53.2](https://github.com/CosmWasm/wasmd/compare/v0.53.0...v0.53.2) and the .
+However, if you are on an older version of wasmd, you will also be using a different version of wasmvm. We provide the required patches for wasmvm in versions 2.1.4, 2.0.5, 1.5.7.
 To upgrade using this method:
 
 1. Check the current wasmvm version: `go list -m github.com/CosmWasm/wasmvm` and upgrade
    to the closest patched version.
-2. Bump the github.com/CosmWasm/wasmvm dependency in your go.mod to the closest compatible patched version (either 2.1.4, 2.0.5 or 1.5.6); go mod tidy; commit.
+2. Bump the github.com/CosmWasm/wasmvm dependency in your go.mod to the closest compatible patched version (either 2.1.4, 2.0.5 or 1.5.7); go mod tidy; commit.
 3. Apply the patch linked above to your version of wasmd.
 4. If you use the static libraries `libwasmvm_muslc.aarch64.a`/`libwasmvm_muslc.x86_64.a`, make sure that you use the same version as your wasmvm version.
 5. Follow your regular practices to deploy chain upgrades.
 
 To double check if the correct library version is loaded at runtime, use this query:
-`<appd> query wasm libwasmvm-version`. It must show 2.1.4, 2.0.5 or 1.5.6 and must be the same as the wasmvm version in your go.sum.
+`<appd> query wasm libwasmvm-version`. It must show 2.1.4, 2.0.5 or 1.5.7 and must be the same as the wasmvm version in your go.sum.
 
 The patch is not consensus breaking as long as you were using the previous patch version of wasmvm before.
 


### PR DESCRIPTION
We fixed the API for the 1.5 fix and released that as 1.5.7, so the patch should refer to that.

Pino also finished the patch for wasmd 0.34 in https://github.com/CosmWasm/wasmd/pull/2075 (only the update to 1.5.7 is still missing)
Since we have the fix now anyways, we can also just release it as 0.34.1