### PR TITLE
Add missing descriptions for CWA-2024-006, CWA-2024-007 and CWA-2024-008

### DIFF
--- a/CWAs/CWA-2024-006.md
+++ b/CWAs/CWA-2024-006.md
@@ -12,7 +12,8 @@ Medium (Moderate + Likely)[^1]
 
 ## Description of the bug
 
-(Blank for now. We'll add more detail once chains had a chance to upgrade.)
+Wasmd's `SmartContractState` query was marked as `module_query_safe` in wasmd 0.52.0,
+but in some cases, this query can be non-deterministic. This can lead to a chain halt.
 
 ## Patch
 

--- a/CWAs/CWA-2024-007.md
+++ b/CWAs/CWA-2024-007.md
@@ -20,7 +20,7 @@ Medium (Moderate + Likely)[^1]
 
 ## Description of the bug
 
-Incorrect tracking of gas in wasmer can lead to a contract consuming much more CPU time than it should be allowed to,
+Incorrect tracking of gas in Wasmer can lead to a contract consuming much more CPU time than it should be allowed to,
 given our [gas target](https://github.com/CosmWasm/cosmwasm/blob/e50490c4199a234200a497219b27f071c3409f58/docs/GAS.md#cosmwasm-gas-pricing).
 This can be used to temporarily DoS a chain by stalling block production.
 

--- a/CWAs/CWA-2024-007.md
+++ b/CWAs/CWA-2024-007.md
@@ -20,7 +20,11 @@ Medium (Moderate + Likely)[^1]
 
 ## Description of the bug
 
-(Blank for now. We'll add more detail once chains had a chance to upgrade.)
+Incorrect tracking of gas in wasmer can lead to a contract consuming much more CPU time than it should be allowed to,
+given our [gas target](https://github.com/CosmWasm/cosmwasm/blob/e50490c4199a234200a497219b27f071c3409f58/docs/GAS.md#cosmwasm-gas-pricing).
+This can be used to temporarily DoS a chain by stalling block production.
+
+We have written an [in-depth article](https://medium.com/cosmwasm/metering-is-hard-cosmwasm-security-issues-explained-a797511cd54e) about this issue.
 
 ## Patch
 

--- a/CWAs/CWA-2024-008.md
+++ b/CWAs/CWA-2024-008.md
@@ -20,7 +20,11 @@ Medium (Moderate + Likely)[^1]
 
 ## Description of the bug
 
-(Blank for now. We'll add more detail once chains had a chance to upgrade.)
+A contract can prevent gas from being reported back to the chain by causing a panic in the host,
+which means it can consume lots of CPU time without paying gas.
+This can be used to DoS a chain by stalling block production.
+
+We have written an [in-depth article](https://medium.com/cosmwasm/metering-is-hard-cosmwasm-security-issues-explained-a797511cd54e) about this issue.
 
 ## Patch
 


### PR DESCRIPTION
These have been patched for ~6 months already and we even published the article for 7 & 8 already, so might as well add the descriptions now.