### PR TITLE
Striked through the 1.5 LTS

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # CosmWasm Advisories
 
-We at [Confio](https://confio.gmbh/) love open source! We work in the best intent with a public review process but must accept that software can contains bugs and therefore our code, too.
+We at [Confio](https://confio.gmbh/) love open source! We work in the best intent with a public review process but must accept that software can contain bugs and therefore our code, too.
 
 In order to help with resolving any issues on production system, we have started the advisories project to link to authorized communication channels of [CosmWasm](https://cosmwasm.com/) blockchains.
-Confio will inform the linked chains about **critical issues** reported to us directly on **non public channels** before opening an issue on our related projects.
-Nevertheless providing this information should not prevent us or anybody else from working on a fix nor block a patch roll out.
-This also does not include bugs and issues reported to us publicly via github issues or official discord channels. Chains using our projects are encouraged to **watch the github repos and official channels** on [CosmWasm discord](https://discord.com/invite/cPjEnPd) in order to maintain their own software stack.
+Confio will inform the linked chains about **critical issues** reported to us directly on **non-public channels** before opening an issue on our related projects.
+Nevertheless, providing this information should not prevent us or anybody else from working on a fix nor block a patch roll out.
+This also does not include bugs and issues reported to us publicly via GitHub issues or official discord channels. Chains using our projects are encouraged to **watch the GitHub repos and official channels** on [CosmWasm discord](https://discord.com/invite/cPjEnPd) in order to maintain their own software stack.
 
 ## Supported projects and version
 
@@ -13,7 +13,7 @@ This also does not include bugs and issues reported to us publicly via github is
   - ~1.2.x ([until 2023-12-31](https://medium.com/cosmwasm/eol-for-cosmwasm-1-0-1-3-22df4b34b13c))~
   - ~1.3.x ([until 2024-03-31](https://medium.com/cosmwasm/eol-for-cosmwasm-1-0-1-3-22df4b34b13c))~
   - ~1.4.x ([until 2024-07-31](https://medium.com/cosmwasm/cosmwasm-1-5-becomes-long-term-support-lts-version-16632bf06f2a))~
-  - 1.5.x ([until 2025-04-30](https://medium.com/cosmwasm/cosmwasm-2-2-becomes-long-term-support-lts-version-7fdd6a507485))
+  - ~1.5.x ([until 2025-04-30](https://medium.com/cosmwasm/cosmwasm-2-2-becomes-long-term-support-lts-version-7fdd6a507485))~
   - ~2.0.x ([until 2025-01-31](https://medium.com/cosmwasm/cosmwasm-2-2-becomes-long-term-support-lts-version-7fdd6a507485))~
   - ~2.1.x ([until 2025-01-31](https://medium.com/cosmwasm/cosmwasm-2-2-becomes-long-term-support-lts-version-7fdd6a507485))~
   - 2.2.x
@@ -22,29 +22,22 @@ This also does not include bugs and issues reported to us publicly via github is
 
 ## Criteria to get on the notification list
 
-- Run CosmWasm projects **on prodution** or public testnet
-- `SECURITY.md` in your main repo and main branch with contact details and infos on your disclosure process
-- Commitment to share issues and bugs with Confio and the CosmWasm community
+- Running CosmWasm projects **on production** or public testnet.
+- `SECURITY.md` placed in your main repo and main branch with contact details and infos on your disclosure process.
+- Commitment to share issues and bugs with Confio and the CosmWasm community.
 
-If your project matches these criteria then please do a PR to add your chain to the list below.
+If your project meets these criteria, please submit a PR to add your chain to the list below.
 
 ## Disclaimer
 
 We likely will not have capacity to maintain this service for all versions and projects forever.
+
 So we want to keep the right to:
 
-- modify this document
-- add/remove project and versions
-- change the criterias and revisit the listed members
-- not accept every application
-
-<!--
-# legal stuff about:
-
-brand(s)
-logo(s)
-
--->
+- modify this document,
+- add/remove project and versions,
+- change the criteria and revisit the listed members,
+- not accept every application.
 
 ## Notification list
 


### PR DESCRIPTION
- According this article (and public information) https://medium.com/cosmwasm/cosmwasm-1-5-becomes-long-term-support-lts-version-16632bf06f2a, LTS for version 1.5 os now over so I marked this as striked-through in the README file.
- Fixed some typos and style.