### PR TITLE
Updated mintained versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,12 +31,12 @@ in order to maintain their own software stack.
   - ~1.5.x ([until 2025-04-30](https://medium.com/cosmwasm/cosmwasm-2-2-becomes-long-term-support-lts-version-7fdd6a507485))~
   - ~2.0.x ([until 2025-01-31](https://medium.com/cosmwasm/cosmwasm-2-2-becomes-long-term-support-lts-version-7fdd6a507485))~
   - ~2.1.x ([until 2025-01-31](https://medium.com/cosmwasm/cosmwasm-2-2-becomes-long-term-support-lts-version-7fdd6a507485))~
-  - 2.2.x ([until 2026-06-30](https://medium.com/cosmwasm/cosmwasm-2-2-becomes-long-term-support-lts-version-7fdd6a507485))
-  - 2.3.x ([until 2026-06-30](https://medium.com/cosmwasm/cosmwasm-2-2-becomes-long-term-support-lts-version-7fdd6a507485))
+  - ~2.2.x ([until 2026-05-31](https://medium.com/cosmwasm/cosmwasm-2-2-becomes-long-term-support-lts-version-7fdd6a507485))~
+  - 2.3.x (until 2026-09-30)
   - 3.0.x (until 2026-12-31)
 - [wasmd]
-  - 0.54.x
   - 0.6x.x
+  - 0.7x.x
 - [cw-plus], [cw-storage-plus], [cw-utils]
   - 2.2.x
 


### PR DESCRIPTION
Updated maintained version based on [Release Families](https://docs.cosmos.network/sdk/latest/release-family).
- **wasmd** series `0.54.x` is not maintained anymore, because Cosmos SDK v0.50.x and lower is not maintained,
- as a consequence, CosmWasm libraries series `2.2.x` is not maintained anymore, because it is used only in **wasmd** `0.54.x`,
- a new **wasmd** `0.70.x` series is maintained.

All supported and maintained versions are lister [here](https://cosmwasm.github.io/maintainers/versions).